### PR TITLE
Added calculator sidebar with jQuery functionality

### DIFF
--- a/app/assets/javascripts/calculator_selection.js
+++ b/app/assets/javascripts/calculator_selection.js
@@ -7,6 +7,6 @@ $(document).ready(function() {
     console.log("Clicked on a column name: " + columnName);
     console.log(tableName);
     console.log("Closest table name: " + tableName);
-    
+    $(".well").append("<p>" + tableName + " " + columnName + "</p>");
   });
 });

--- a/app/assets/javascripts/calculator_selection.js
+++ b/app/assets/javascripts/calculator_selection.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+  console.log("Document is ready!");
+  $(".tables").on("click", "p", function() {
+    var tableName = $(this).parent().find('h1').get(0).innerText;
+    var columnName = $(this).text();
+    console.log($(this));
+    console.log("Clicked on a column name: " + columnName);
+    console.log(tableName);
+    console.log("Closest table name: " + tableName);
+    
+  });
+});

--- a/app/assets/javascripts/calculator_selection.js
+++ b/app/assets/javascripts/calculator_selection.js
@@ -1,5 +1,9 @@
 $(document).ready(function() {
   console.log("Document is ready!");
+
+  var jqueryParams = {};
+  var clickCount = 0;
+
   $(".tables").on("click", "p", function() {
     var tableName = $(this).parent().find('h1').get(0).innerText;
     var columnName = $(this).text();
@@ -8,5 +12,9 @@ $(document).ready(function() {
     console.log(tableName);
     console.log("Closest table name: " + tableName);
     $(".well").append("<p>" + tableName + " " + columnName + "</p>");
+    jqueryParams[clickCount] = { selectionTable: tableName, selectionColumn: columnName }
+    console.log(jqueryParams);
+    clickCount++;
+    console.log(clickCount);
   });
 });

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -4,10 +4,12 @@
   <div class="col-md-8">
     <div class="tables">
       <% all_tables.each do |table| %>
-        <h1> <%= table %> </h1>
-        <% table.singularize.camelize.constantize.column_names.each do |column| %>
-          <p> <%= column %> </p>
-        <% end %>
+        <div class="table-container">
+          <h1> <%= table %> </h1>
+          <% table.singularize.camelize.constantize.column_names.each do |column| %>
+            <p> <%= column %> </p>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
When clicking on a column name inside a given table, that table's name and the selected column now appear on the calculator sidebar.  Those attributes are also added to a JS object in memory.
